### PR TITLE
Update agent to more accurately locate a running agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -21,50 +21,47 @@ define gpg::agent (
 
   require gpg
 
-  $command = join(
-    [
-      'gpg-agent',
-      '--allow-preset-passphrase',
-      '--write-env-file',
-      $outfile,
-      '--daemon',
-      join($options, ' ')
-    ], ' ')
-
-  $preload_passphrase = join(
-    [
-      '/usr/lib/gnupg2/gpg-preset-passphrase -v',
-      '--passphrase',
-      $gpg_passphrase,
-      '--preset',
-      $gpg_key_grip
-    ], ' ')
-
-  Exec {
-    path => $path,
-    user => $user
-  }
+  $check_for_agent = 'sh -c gpg-agent'
 
   case $ensure {
     present: {
       exec { "gpg-agent for ${name}":
-        command   => $command,
-        unless    => "ps -U ${user} -o args | grep -v grep | grep gpg-agent",
+        path      => $path,
+        user      => $user,
+        unless    => $check_for_agent,
         logoutput => on_failure,
+        command   => join( [
+          'gpg-agent',
+          '--allow-preset-passphrase',
+          '--write-env-file',
+          $outfile,
+          '--daemon',
+          join($options, ' ')
+        ], ' ')
       }
       if $gpg_passphrase {
         exec { "set gpg-agent ${name} passphrase":
-          command     => $preload_passphrase,
-          onlyif      => "ps -U ${user} -o args | grep -v grep | grep gpg-agent",
+          path        => $path,
+          user        => $user,
+          onlyif      => $check_for_agent,
           refreshonly => true,
-          subscribe   => Exec["gpg-agent for ${name}"]
+          subscribe   => Exec["gpg-agent for ${name}"],
+          command     => join( [
+            '/usr/lib/gnupg2/gpg-preset-passphrase -v',
+            '--passphrase',
+            $gpg_passphrase,
+            '--preset',
+            $gpg_key_grip,
+          ], ' ')
         }
       }
     }
     absent: {
       exec { "kill gpg-agent for ${name}":
-        command => "ps -U ${name} -eo pid,args | grep -v grep | grep gpg-agent | xargs kill",
-        onlyif  => "ps -U ${name} -o args | grep -v grep | grep gpg-agent",
+        path    => $path,
+        user    => $user,
+        command => 'ps aux | grep "[g]pg-agent --allow-preset-passphrase" | xargs kill',
+        onlyif  => $check_for_agent,
       }
     }
     default: {


### PR DESCRIPTION
This commit updates the gpg agent class in order to more accurately
determine whether an agent is running by using the gpg-agent command.
Without this change ps is used to look for gpg-agent, which can be
difficult to locate because jobs run that consume the gpg agent. When
this happens the agent does not start because it incorrectly determines
that it is already running.
Additionally, the agent manifest is re-arragned to make more clear the
commands that are running.