### PR TITLE
Add management of the gpg-agent package

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -16,7 +16,8 @@ define gpg::agent (
   $options        = [],
   $gpg_passphrase = undef,
   $gpg_key_grip   = undef,
-  $user           = $name
+  $user           = $name,
+  $manage_pkg     = true
 ) {
 
   require gpg
@@ -25,6 +26,10 @@ define gpg::agent (
 
   case $ensure {
     present: {
+      if $manage_pkg {
+        include ::gpg::install
+      }
+
       exec { "gpg-agent for ${name}":
         path      => $path,
         user      => $user,
@@ -39,6 +44,7 @@ define gpg::agent (
           join($options, ' ')
         ], ' ')
       }
+
       if $gpg_passphrase {
         exec { "set gpg-agent ${name} passphrase":
           path        => $path,
@@ -56,6 +62,7 @@ define gpg::agent (
         }
       }
     }
+
     absent: {
       exec { "kill gpg-agent for ${name}":
         path    => $path,
@@ -64,6 +71,7 @@ define gpg::agent (
         onlyif  => $check_for_agent,
       }
     }
+
     default: {
       fail("Undefined ensure parameter \"${ensure}\" for gpg::agent")
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,20 @@
+# A class to provide the gpg agent package
+class gpg::install (
+  $ensure      = present,
+  $pkg_version = latest
+) {
+
+  case $::operatingsystem {
+    'Debian', 'Ubuntu': { $gpg_agent_pkg = 'gnupg-agent' }
+    'CentOS': { $gpg_agent_pkg = 'gnupg2' }
+    default: {
+      notify { "No gpg-agent package is configured for ${::operatingsystem}": }
+    }
+  }
+
+  if $gpg_agent_pkg {
+    package { $gpg_agent_pkg:
+      ensure => $pkg_version
+    }
+  }
+}


### PR DESCRIPTION
This commit adds management of the gpg-agent package for debian and ubuntu. Additionally, a flag is provided in order to enable or disable package management of the agent. Additionally, spacing is added in the agent manifest in order to make it more readable. Without this change the agent package must be deployed manually in order for gpg::agent to work.
